### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -183,12 +183,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "b7ab3a803b377d9353526bf38a98ca1193877a7a"
+                "reference": "f2efa5d9d620b194cda6a6698447a2dad451a7a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b7ab3a803b377d9353526bf38a98ca1193877a7a",
-                "reference": "b7ab3a803b377d9353526bf38a98ca1193877a7a",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f2efa5d9d620b194cda6a6698447a2dad451a7a3",
+                "reference": "f2efa5d9d620b194cda6a6698447a2dad451a7a3",
                 "shasum": ""
             },
             "require": {
@@ -219,7 +219,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable27"
             },
-            "time": "2023-10-28T00:30:08+00:00"
+            "time": "2023-11-11T00:31:29+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency