### PR TITLE
chore(release): Add changelog and set version to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 1.1.1 - 2024-06-07
+### Fixed
+- Fix an issue with local domains and self-signed certificates
+
 ## 1.1.0 - 2024-03-08
 ### Added
 - Nextcloud 29 compatibility

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 - You can also post multiple tasks in a single message, just put each on its own line starting with a keyword
 - At the end of the call, the bot will summarize it and list all the attendees as well as the tasks in a markdown chat message]]></description>
 
-	<version>1.1.0</version>
+	<version>1.1.1</version>
 	<licence>agpl</licence>
 
 	<author>Joas Schilling</author>


### PR DESCRIPTION
## 1.1.1 - 2024-06-07
### Fixed
- Fix an issue with local domains and self-signed certificates [#68](https://github.com/nextcloud/call_summary_bot/pull/68)