### PR TITLE
fix(attachments): Correctly track messages with attachments

### DIFF
--- a/tests/Service/SummaryServiceTest.php
+++ b/tests/Service/SummaryServiceTest.php
@@ -149,7 +149,7 @@ class SummaryServiceTest extends TestCase {
 				->method('saveTask');
 		}
 
-		self::assertEquals(!empty($tasks), $service->readTasksFromMessage($message, ['parameters' => []], ['target' => ['id' => 't0k3n']]));
+		self::assertEquals(!empty($tasks), $service->readTasksFromMessage($message, ['parameters' => []], ['target' => ['id' => 't0k3n']], false, 'en'));
 	}
 
 	public static function dataGetTitle(): array {


### PR DESCRIPTION
- Fix #185 

Agenda item | task/decision/result
---|---
<img width="1108" height="451" alt="Bildschirmfoto vom 2026-01-14 16-50-14" src="https://github.com/user-attachments/assets/e6ff5d28-6235-4067-9a07-542a23358f3e" /> | <img width="1113" height="697" alt="grafik" src="https://github.com/user-attachments/assets/64debf7b-4bc6-4562-9f09-59c502054741" />
