### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "57cd9c3fbdbba2263544dabeca8f5a3874aa8ced"
+                "reference": "d23138a46126bef1f3aea157a80c53638d8e37b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/57cd9c3fbdbba2263544dabeca8f5a3874aa8ced",
-                "reference": "57cd9c3fbdbba2263544dabeca8f5a3874aa8ced",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d23138a46126bef1f3aea157a80c53638d8e37b7",
+                "reference": "d23138a46126bef1f3aea157a80c53638d8e37b7",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2026-02-20T01:07:07+00:00"
+            "time": "2026-03-20T01:09:10+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency