### PR TITLE
Add attendee count to summary

### DIFF
--- a/lib/Service/SummaryService.php
+++ b/lib/Service/SummaryService.php
@@ -264,7 +264,7 @@ class SummaryService {
 		}
 
 		$summary .= "\n";
-		$summary .= '## ' . $l->t('Attendees') . "\n";
+		$summary .= '## ' . $l->t('Attendees') . ' (' . count($attendees) . ")\n";
 		foreach ($attendees as $attendee) {
 			$summary .= '- ' . $attendee . "\n";
 		}


### PR DESCRIPTION
Just as a nice little summary. Since we have a similar count in the participants tab in the sidebar, and a live counter in the call, it felt missing here. :)

Before | After
-|-
<img width="641" height="330" alt="Screenshot From 2026-04-15 17-55-38" src="https://github.com/user-attachments/assets/ea2a1e7f-a507-4725-887b-91ebbc48be57" />|<img width="612" height="366" alt="Screenshot From 2026-04-15 17-55-26" src="https://github.com/user-attachments/assets/646f3987-dc4c-4771-8652-e15d0e933734" />
